### PR TITLE
Update tezos-snapshot-metadata.schema.json

### DIFF
--- a/tezos-snapshot-metadata.schema.json
+++ b/tezos-snapshot-metadata.schema.json
@@ -1,137 +1,141 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema",
+  "type": "object",
   "title": "Tezos Snapshots",
   "description": "List of all available Tezos Snapshots",
   "required": ["data", "org", "date_generated"],
-  "org":{
-    "description": "Organization that published the metadata.",
-    "type": "string"
-  },
-  "date_generated": {
-    "description": "ISO 8601 UTC timestamp of when the metadata was generated.",
-    "type": "string"
-  },
-  "data": {
-    "type": "array",
-    "items": {
-      "type": "object",
-      "description": "The metadata of a single Tezos node storage artifact (snapshot or tarball).",
+  "properties": {
+    "org": {
+      "description": "Organization that published the metadata.",
+      "type": "string"
+    },
+    "date_generated": {
+      "description": "ISO 8601 UTC timestamp of when the metadata was generated.",
+      "type": "string"
+    },
+    "data": {
+      "type": "array",
+      "items": {
       "required": [
         "block_hash",
         "block_height",
         "block_timestamp",
         "filename",
         "url",
+        "history_mode",
         "sha256",
         "filesize_bytes",
         "filesize",
         "tezos_version",
         "chain_name",
         "artifact_type"
-      ],
-      "properties": {
-        "block_hash": {
-          "type": "string",
-          "description": "A reference for a block in the Tezos blockchain.",
-          "examples": ["BMHv8Rmx2QQtN786bUCuAxxemTmdJxaonbmUALifMYtivT13Hxg"]
-        },
-        "block_height": {
-          "type": "integer",
-          "description": "The number of blocks preceding this one in the blockchain",
-          "examples": [23466334, 345667223]
-        },
-        "block_timestamp": {
-          "type": "string",
-          "description": "ISO 8601 timestamp of the current block UTC",
-          "examples": ["2023-01-02T08:17:20Z"]
-        },
-        "filename": {
-          "type": "string",
-          "examples": ["tezos-limanet-rolling-tarball-438782.lz4"]
-        },
-        "url": {
-          "type": "string",
-          "description": "Reference to this file on the web",
-          "examples": [
-            "https://limanet-v15.xtz-shots.io/tezos-limanet-rolling-tarball-438782.lz4"
-          ]
-        },
-        "sha256": {
-          "type": "string",
-          "description": "Hash of the file contents for checking data integrity.",
-          "examples": [
-            "7961409dad2b8ff917551eea4a5178c1a6d95a21f807f1020a34e3acedaaad4c"
-          ]
-        },
-        "filesize_bytes": {
-          "type": "integer",
-          "examples": [53963264, 234234]
-        },
-        "filesize": {
-          "type": "string",
-          "description": "Size of file in kilobytes (K), megabytes (M), gigabytes (G) or terabytes (T)",
-          "examples": ["6G", "51M"]
-        },
-        "tezos_version": {
-          "type": "object",
-          "description": "Tezos version running on the node this data is from",
-          "required": ["implementation", "version", "commit_info"],
-          "properties": {
-            "implementation": {
-              "type": "string",
-              "examples": ["octez", "tezedge"]
-            },
-            "version": {
-              "type": "object",
-              "required": ["major", "minor", "additional_info"],
-              "properties": {
-                "major": {
-                  "type": "integer",
-                  "minimum": 7,
-                  "maximum": 99
-                },
-                "minor": {
-                  "type": "integer",
-                  "minimum": 0,
-                  "maximum": 99
-                },
-                "additional_info": {
-                  "type": "string"
+        ],
+        "type": "object",
+        "description": "The metadata of a single Tezos node storage artifact (snapshot or tarball).",
+        "properties": {
+          "block_hash": {
+            "type": "string",
+            "description": "A reference for a block in the Tezos blockchain.",
+            "examples": ["BMHv8Rmx2QQtN786bUCuAxxemTmdJxaonbmUALifMYtivT13Hxg"]
+          },
+          "block_height": {
+            "type": "integer",
+            "description": "The number of blocks preceding this one in the blockchain",
+            "examples": [23466334, 345667223]
+          },
+          "block_timestamp": {
+            "type": "string",
+            "description": "ISO 8601 timestamp of the current block UTC",
+            "examples": ["2023-01-02T08:17:20Z"]
+          },
+          "filename": {
+            "type": "string",
+            "examples": ["tezos-limanet-rolling-tarball-438782.lz4"]
+          },
+          "url": {
+            "type": "string",
+            "description": "Reference to this file on the web",
+            "examples": [
+              "https://limanet-v15.xtz-shots.io/tezos-limanet-rolling-tarball-438782.lz4"
+            ]
+          },
+          "sha256": {
+            "type": "string",
+            "description": "Hash of the file contents for checking data integrity.",
+            "examples": [
+              "7961409dad2b8ff917551eea4a5178c1a6d95a21f807f1020a34e3acedaaad4c"
+            ]
+          },
+          "filesize_bytes": {
+            "type": "integer",
+            "examples": [53963264, 234234]
+          },
+          "filesize": {
+            "type": "string",
+            "description": "Size of file in kilobytes (K), megabytes (M), gigabytes (G) or terabytes (T)",
+            "examples": ["6G", "51M"]
+          },
+          "tezos_version": {
+            "type": "object",
+            "description": "Tezos version running on the node this data is from",
+            "required": ["implementation", "version", "commit_info"],
+            "properties": {
+              "implementation": {
+                "type": "string",
+                "examples": ["octez", "tezedge"]
+              },
+              "version": {
+                "type": "object",
+                "required": ["major", "minor", "additional_info"],
+                "properties": {
+                  "major": {
+                    "type": "integer",
+                    "minimum": 7,
+                    "maximum": 99
+                  },
+                  "minor": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 99
+                  },
+                  "additional_info": {
+                    "type": ["string", "object"]
+                  }
                 }
-              }
-            },
-            "commit_info": {
-              "required": ["commit_hash", "commit_date"],
-              "properties": {
-                "commit_hash": {
-                  "type": "string"
-                },
-                "commit_date": {
-                  "type": "string"
+              },
+              "commit_info": {
+                "required": ["commit_hash", "commit_date"],
+                "properties": {
+                  "commit_hash": {
+                    "type": "string"
+                  },
+                  "commit_date": {
+                    "type": "string"
+                  }
                 }
               }
             }
+          },
+          "chain_name": {
+            "type": "string",
+            "description": "Name of Tezos blockchain",
+            "examples": ["TEZOS_MAINNET", "TEZOS_LIMANET_2022-10-13T15:00:00Z"]
+          },
+          "history_mode": {
+            "type": "string",
+            "description": "Type of chain data contained in snapshot",
+            "enum": ["archive", "full", "rolling"]
+          },
+          "artifact_type": {
+            "type": "string",
+            "description": "Tarball or Tezos Snapshot",
+            "enum": ["tarball", "tezos-snapshot"]
+          },
+          "snapshot_version": {
+            "type": "integer",
+            "description": "Version of Octez snapshot format. Tarball will not have a snapshot_version.",
+            "examples": [5, 4]
           }
-        },
-        "chain_name": {
-          "type": "string",
-          "description": "Name of Tezos blockchain",
-          "examples": ["TEZOS_MAINNET", "TEZOS_LIMANET_2022-10-13T15:00:00Z"]
-        },
-        "history_mode": {
-          "type": "string",
-          "description": "Type of chain data contained in snapshot",
-          "enum": ["archive", "full", "rolling"]
-        },
-        "artifact_type": {
-          "type": "string",
-          "description": "Tarball or Tezos Snapshot",
-          "enum": ["tarball", "tezos-snapshot"]
-        },
-        "snapshot_version": {
-          "type": "integer",
-          "description": "Version of Octez snapshot format. Tarball will not have a snapshot_version.",
-          "examples": [5, 4]
         }
       }
     }


### PR DESCRIPTION
Fixes nesting issues that was causing the schema not actually enforce mandatory values.